### PR TITLE
Fixed wrong translation paths in sign up with with confirmation docs

### DIFF
--- a/docs/usage_sign_up_with_confirmation.md
+++ b/docs/usage_sign_up_with_confirmation.md
@@ -73,9 +73,9 @@ $resourcesPath = __DIR__ . '/../vendor/bengor-user/twig-bridge/src/BenGorUser/Tw
 
 $translator = new \Symfony\Component\Translation\Translator('en_US');
 $translator->addLoader('xlf', new \Symfony\Component\Translation\Loader\XliffFileLoader());
-$translator->addResource('xlf', $resourcesPath . '/Translations/BenGorUser.es.xlf', 'es_ES', 'BenGorUser');
-$translator->addResource('xlf', $resourcesPath . '/Translations/BenGorUser.en.xlf', 'en_US', 'BenGorUser');
-$translator->addResource('xlf', $resourcesPath . '/Translations/BenGorUser.eu.xlf', 'eu_ES', 'BenGorUser');
+$translator->addResource('xlf', $resourcesPath . '/Translations/BenGorUser.es_ES.xlf', 'es_ES', 'BenGorUser');
+$translator->addResource('xlf', $resourcesPath . '/Translations/BenGorUser.en_US.xlf', 'en_US', 'BenGorUser');
+$translator->addResource('xlf', $resourcesPath . '/Translations/BenGorUser.eu_ES.xlf', 'eu_ES', 'BenGorUser');
 
 $loader = new Twig_Loader_Filesystem($resourcesPath . '/Twig/views');
 $twig = new \Twig_Environment($loader);


### PR DESCRIPTION
Moving from v1.0.0 to v1.0.1 in TwigBridge generates a small BC break after changing the locales of the translation files, therefore the fixed paths no longer exist
