### PR TITLE
[bug-fix] Permission Revoke

### DIFF
--- a/src/BenGorUser/User/Domain/Model/User.php
+++ b/src/BenGorUser/User/Domain/Model/User.php
@@ -569,7 +569,7 @@ class User extends UserAggregateRoot
                 break;
             }
         }
-        if ($index == $numberOfRoles) {
+        if ($index === $numberOfRoles) {
             throw new UserRoleAlreadyRevokedException();
         }
 

--- a/src/BenGorUser/User/Domain/Model/User.php
+++ b/src/BenGorUser/User/Domain/Model/User.php
@@ -558,14 +558,21 @@ class User extends UserAggregateRoot
         if (false === $this->isRoleAllowed($aRole)) {
             throw new UserRoleInvalidException();
         }
-        foreach ($this->roles as $key => $role) {
+
+        $numberOfRoles = count($this->roles);
+        for ($index = 0; $index < $numberOfRoles; $index++) {
+            $role = $this->roles[$index];
+
             if ($role->equals($aRole)) {
-                unset($this->roles[$key]);
+                unset($this->roles[$index]);
                 $this->roles = array_values($this->roles);
                 break;
             }
+        }
+        if ($index == $numberOfRoles) {
             throw new UserRoleAlreadyRevokedException();
         }
+
         $this->updatedOn = new \DateTimeImmutable();
         $this->publish(
             new UserRoleRevoked(


### PR DESCRIPTION
User permission could only be revoked if the first role matches with the inner array.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | no
| License       | MIT
| Doc PR        | none
